### PR TITLE
Bug/56/roadmap pagination transition

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -61,7 +61,7 @@ export default function RootLayout({
       </head>
       <body className="group antialiased">
         <Suspense>
-          <FilterProvider>
+          <FilterProvider basePath="/">
             <ThemeProvider
               attribute="class"
               defaultTheme="system"

--- a/src/components/FilterProvider.tsx
+++ b/src/components/FilterProvider.tsx
@@ -21,6 +21,10 @@ type FilterContextType = {
   updateFilters: (_value: Filters) => void;
 };
 
+type FilterProviderProps = PropsWithChildren<{
+  basePath?: string;
+}>;
+
 export const FilterContext = createContext<FilterContextType | undefined>(
   undefined,
 );
@@ -33,7 +37,10 @@ export function useFilters() {
   return context;
 }
 
-export default function FilterProvider({ children }: PropsWithChildren) {
+export default function FilterProvider({
+  basePath = "/",
+  children,
+}: FilterProviderProps) {
   const searchParams = useSearchParams();
   const router = useRouter();
 
@@ -73,7 +80,7 @@ export default function FilterProvider({ children }: PropsWithChildren) {
 
     startTransition(() => {
       setOptimisticFilters(updates || {});
-      router.push(`/?${newSearchParams}`, { scroll: false });
+      router.push(`${basePath}?${newSearchParams}`, { scroll: false });
     });
   }
 

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useOptimistic, useTransition } from "react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useTransition } from "react";
 import {
   Pagination as PaginationComponent,
   PaginationContent,
@@ -10,6 +9,7 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@/components/ui/pagination";
+import { useFilters } from "./FilterProvider";
 
 type PaginationedListProps = {
   totalCount: number;
@@ -20,51 +20,42 @@ export default function Pagination({
   totalCount,
   limit = 6,
 }: PaginationedListProps) {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-
   const totalPage = Math.ceil(totalCount / limit);
   const [isPending, startTransition] = useTransition();
-  const [optimisticCurrentPage, setOptimisticCurrentPage] = useOptimistic(
-    parseInt(searchParams.get("page") || "1"),
-  );
+  const { filters, updateFilters } = useFilters(); // Use the nearest Filter context
 
+  const currentPage = filters.page || 1;
   const handlePaginationClick = (page: number) => {
-    const params = new URLSearchParams(searchParams);
-
     startTransition(() => {
-      setOptimisticCurrentPage(page);
-      params.set("page", page.toString());
-      router.push(`${pathname}?${params.toString()}`);
+      updateFilters({ page });
     });
   };
 
   return (
     <PaginationComponent data-pending={isPending ? "" : undefined}>
       <PaginationContent className="flex-wrap justify-center">
-        {optimisticCurrentPage > 1 && (
+        {currentPage > 1 && (
           <PaginationItem>
             <PaginationPrevious
-              onClick={() => handlePaginationClick(optimisticCurrentPage - 1)}
+              onClick={() => handlePaginationClick(currentPage - 1)}
             />
           </PaginationItem>
         )}
         {[...Array(totalPage)].map((_, index) => (
           <PaginationItem key={index}>
             <PaginationLink
-              isActive={index + 1 === optimisticCurrentPage}
+              isActive={index + 1 === currentPage}
               onClick={() => handlePaginationClick(index + 1)}
             >
               {index + 1}
             </PaginationLink>
           </PaginationItem>
         ))}
-        {optimisticCurrentPage < totalPage && (
+        {currentPage < totalPage && (
           <>
             <PaginationItem>
               <PaginationNext
-                onClick={() => handlePaginationClick(optimisticCurrentPage + 1)}
+                onClick={() => handlePaginationClick(currentPage + 1)}
               />
             </PaginationItem>
           </>


### PR DESCRIPTION
## ❓이슈

- close #56

## :memo: Description

### 주요 변경 사항
- FilterProvider에 basePath를 주입받도록 개선 
- 페이지네이션 이동 로직을 Filter context의 updateFilters를 이용하도록 변경

### FilterProvider에 basePath를 주입한 이유
마이페이지 등 특정 하위 경로에서 독립적인 필터/페이지네이션 상태를 갖도록 하기 위해, 해당 컴포넌트 영역에 FilterProvider를 한 번 더 감쌀 예정입니다.

이때, 가장 가까운 FilterContext만 소비되도록 하고, 동시에 router.push가 의도한 경로로 동작할 수 있도록 하기 위해 basePath 주입했습니다.


<!-- 어떤 내용의 PR인지 작성해 주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정
