### PR TITLE
Bug/67/logoin middleware conflict

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import LoginHeader from "@/features/auth/components/LoginHeader";
 import SocialLogin from "@/features/auth/components/SocialLogin";
+import { authClient } from "@/lib/auth-client";
 
 export default function LoginPage() {
+  const router = useRouter();
+  const { data: session } = authClient.useSession();
+
+  useEffect(() => {
+    if (session) {
+      router.replace("/");
+    }
+  }, [router, session]);
+
+  if (session) {
+    return null;
+  }
+
   return (
     <div className="mx-auto flex w-full max-w-xs items-center justify-center py-24 md:py-20">
       <div className="space-y-8">

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,14 +3,6 @@ import { getSessionCookie } from "better-auth/cookies";
 
 export async function middleware(request: NextRequest) {
   const sessionCookie = getSessionCookie(request);
-  const pathname = request.nextUrl.pathname;
-
-  if (pathname.startsWith("/login")) {
-    if (sessionCookie) {
-      return NextResponse.redirect(new URL("/", request.url));
-    }
-    return NextResponse.next();
-  }
 
   if (!sessionCookie) {
     return NextResponse.redirect(new URL("/login", request.url));
@@ -20,10 +12,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: [
-    "/my/:path*",
-    "/roadmap/create/:path*",
-    "/roadmap/edit/:path*",
-    "/login",
-  ],
+  matcher: ["/my/:path*", "/roadmap/create/:path*", "/roadmap/edit/:path*"],
 };


### PR DESCRIPTION
## ❓이슈

- close #67

## :memo: Description

<!-- 어떤 내용의 PR인지 작성해 주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->
### 🛠 문제 원인 및 해결
#### 🔍 문제 원인
- 소셜 로그인 중 외부 사이트로 이동했다가 뒤로가기로 복귀할 경우, 브라우저는 캐시된 /login 페이지의 RSC payload를 사용해 hydrate를 시도합니다. 
- 하지만 이 시도중 서버가 응답한 HTML과 RSC 구조가 완벽히 일치하지 않아서, React는 hydrate를 실패하고 RSC payload가 그대로 노출되는 현상이 있습니다.

#### ✅ 해결 방법
- `/login` 페이지에서 로그인된 사용자를 서버에서 redirect하지 않고, 클라이언트에서 `useEffect`를 사용해 `router.replace()`로 리디렉션하도록 변경합니다.
- 이를 통해 브라우저가 페이지를 복원할 때 항상 동일한 React 트리 구조로 hydrate할 수 있어, 문제를 방지할 수 있습니다.

## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정
