### PR TITLE
Bug/70/bfcache

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,22 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
 import LoginHeader from "@/features/auth/components/LoginHeader";
 import SocialLogin from "@/features/auth/components/SocialLogin";
+import { auth } from "@/lib/auth";
 
-export default function LoginPage() {
+// 1) ignore bfcache - 1
+// export const dynamic = "force-dynamic";
+
+export default async function LoginPage() {
+  // 2) ignore bfcache - 2
+  const session = await auth.api.getSession({
+    headers: await headers(),
+  });
+
+  if (session) {
+    redirect("/");
+  }
+
   return (
     <div className="mx-auto flex w-full max-w-xs items-center justify-center py-24 md:py-20">
       <div className="space-y-8">

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,14 +3,6 @@ import { getSessionCookie } from "better-auth/cookies";
 
 export async function middleware(request: NextRequest) {
   const sessionCookie = getSessionCookie(request);
-  const pathname = request.nextUrl.pathname;
-
-  if (pathname.startsWith("/login")) {
-    if (sessionCookie) {
-      return NextResponse.redirect(new URL("/", request.url));
-    }
-    return NextResponse.next();
-  }
 
   if (!sessionCookie) {
     return NextResponse.redirect(new URL("/login", request.url));


### PR DESCRIPTION
## ❓이슈

- close #70

## :memo: Description

<!-- 어떤 내용의 PR인지 작성해 주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->
### 🛠 문제 원인 및 해결

#### 🔍 문제 원인
로그인 페이지(/login)에 prefetch, router.push(), <Link> 태그 등의 soft navigation을 통해 진입한 경우,
Next.js는 해당 페이지를 HTML이 아닌 RSC payload 형태로 받아 클라이언트에서 조립합니다.

그런데 브라우저에서 소셜 로그인 버튼 클릭 후 외부 인증 페이지로 이동했다가,
사용자가 브라우저의 뒤로 가기를 눌러 /login으로 돌아올 경우,
브라우저는 /login 진입 시 받아두었던 RSC payload를 해당 주소의 페이지 데이터로 간주하고,
이를 **Back-Forward Cache (bfcache)**를 통해 그대로 복원하여 화면에 노출합니다.

이때 앱은 hydration되지 않고, RSC payload의 데이터가 화면에 그대로 노출만 되는 현상이 발생합니다.

#### ✅ 해결 방법
1. 페이지 내부에서 세션을 조회하여 강제로 dynamic rendering 유도
- headers()를 이용해 세션을 조회하는 코드를 추가함으로써, Next.js가 해당 페이지를 자동으로 SSR(dynamic) 처리하도록 만들었습니다.
- 이에 따라 응답에는 Cache-Control: no-store 헤더가 포함되고, 브라우저는 해당 페이지를 bfcache에 저장하지 않게 됩니다.
- 결과적으로 브라우저 뒤로 가기 시에도 서버에서 새로 데이터를 받아 React 앱이 정상적으로 실행됩니다.
- 참고로, 이와 동일한 효과를 얻기 위해 export const dynamic = "force-dynamic"을 선언하는 방법도 있지만, 세션 조회를 통해 자연스럽게 dynamic 처리가 되도록 구성했습니다.

2. middleware에서 세션 기반 리디렉션 로직 제거
- 기존에는 로그인한 사용자가 /login에 접근할 경우 middleware에서 /로 리디렉션하는 로직이 있었으나,
- 이제 해당 로직을 로그인 페이지 내부에서 세션을 직접 조회하여 처리하도록 변경하였기 때문에, middleware에서의 리디렉션은 더 이상 필요하지 않아 제거했습니다.
## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [ ] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [ ] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정
