### PR TITLE
Refactor/form hook action

### DIFF
--- a/src/features/auth/hooks/useProfileMutation.ts
+++ b/src/features/auth/hooks/useProfileMutation.ts
@@ -1,34 +1,22 @@
-import { toast } from "sonner";
+import { useTransition } from "react";
 import { editUserProfileAction } from "@/actions/auth";
-import { authClient } from "@/lib/auth-client";
+import { MutationOption } from "@/types";
 import { UserProfileEditForm } from "../type";
 
-type ProfileMutationOptions = {
-  edit?: {
-    onSuccess?: () => void;
+export const useProfileEdit = (options: MutationOption) => {
+  const [isPending, startTransition] = useTransition();
+
+  const mutate = async (data: UserProfileEditForm) => {
+    startTransition(async () => {
+      const response = await editUserProfileAction(data);
+
+      if (response.success) {
+        options.onSuccess?.(response);
+      } else {
+        options.onError?.(response);
+      }
+    });
   };
-  remove?: {
-    onSuccess?: () => void;
-  };
+
+  return { isPending, mutate };
 };
-
-export default function useProfileMutation(
-  options: ProfileMutationOptions = {},
-) {
-  const edit = async (data: UserProfileEditForm) => {
-    const response = await editUserProfileAction(data);
-
-    if (response.success) {
-      toast.success(response.message);
-      options.edit?.onSuccess?.();
-    } else {
-      toast.error(response.message);
-    }
-  };
-
-  const remove = async () => {
-    await authClient.deleteUser();
-  };
-
-  return { edit, remove };
-}

--- a/src/features/auth/hooks/useProfileMutation.ts
+++ b/src/features/auth/hooks/useProfileMutation.ts
@@ -1,9 +1,11 @@
 import { useTransition } from "react";
 import { editUserProfileAction } from "@/actions/auth";
-import { MutationOption } from "@/types";
+import { MutationOption, MutationResult } from "@/types";
 import { UserProfileEditForm } from "../type";
 
-export const useProfileEdit = (options: MutationOption) => {
+export const useProfileEdit = (
+  options: MutationOption,
+): MutationResult<void, UserProfileEditForm> => {
   const [isPending, startTransition] = useTransition();
 
   const mutate = async (data: UserProfileEditForm) => {

--- a/src/features/comment/components/CommentContent.tsx
+++ b/src/features/comment/components/CommentContent.tsx
@@ -18,7 +18,7 @@ type CommentContentProps = {
   comment: Comment;
   isCommentAuthor?: boolean;
   onEdit: () => void;
-  onDelete: (id: number) => void;
+  onDelete: () => void;
   isPendingDelete: boolean;
 };
 
@@ -68,9 +68,7 @@ export function CommentContent({
                 </AlertDialogHeader>
                 <AlertDialogFooter>
                   <AlertDialogCancel>취소</AlertDialogCancel>
-                  <AlertDialogAction onClick={() => onDelete(comment.id)}>
-                    삭제
-                  </AlertDialogAction>
+                  <AlertDialogAction onClick={onDelete}>삭제</AlertDialogAction>
                 </AlertDialogFooter>
               </AlertDialogContent>
             </AlertDialog>

--- a/src/features/comment/components/CommentForm.tsx
+++ b/src/features/comment/components/CommentForm.tsx
@@ -14,7 +14,8 @@ import {
 } from "@/components/ui/form";
 import { Textarea } from "@/components/ui/textarea";
 import { authClient } from "@/lib/auth-client";
-import useCommentMutation from "../hooks/useCommentMutation";
+import { MutationOption } from "@/types";
+import { useCreateComment, useEditComment } from "../hooks/useCommentMutation";
 import {
   Comment,
   CommentForm as CommentFormType,
@@ -51,22 +52,19 @@ export function CommentForm({
         },
   });
 
-  const { create, edit } = useCommentMutation({
-    create: {
-      onSuccess: () => {
-        form.reset();
-        router.refresh();
-        onComplete?.();
-      },
+  const mutateOptions: MutationOption = {
+    onSuccess: () => {
+      form.reset();
+      router.refresh();
+      onComplete?.();
     },
-    edit: {
-      onSuccess: () => {
-        form.reset();
-        router.refresh();
-        onComplete?.();
-      },
+    onError: (error) => {
+      toast.error(error.message);
     },
-  });
+  };
+
+  const { mutate: create } = useCreateComment(mutateOptions);
+  const { mutate: edit } = useEditComment(mutateOptions);
 
   const action = isEditMode ? edit : create;
 

--- a/src/features/comment/components/CommentItem.tsx
+++ b/src/features/comment/components/CommentItem.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Author from "@/components/Author";
-import useCommentMutation from "../hooks/useCommentMutation";
+import { useDeleteComment } from "../hooks/useCommentMutation";
 import { Comment } from "../type";
 import { CommentContent } from "./CommentContent";
 import { CommentForm } from "./CommentForm";
@@ -13,7 +13,8 @@ type CommentItemProps = {
 };
 export function CommentItem({ comment, isCommentAuthor }: CommentItemProps) {
   const [isEditMode, setIsEditMode] = useState(false);
-  const { remove } = useCommentMutation({ comment });
+  const { mutate: remove, isPending: isPendingRemove } =
+    useDeleteComment(comment);
 
   return (
     <div className="space-y-3">
@@ -32,8 +33,8 @@ export function CommentItem({ comment, isCommentAuthor }: CommentItemProps) {
             comment={comment}
             isCommentAuthor={isCommentAuthor}
             onEdit={() => setIsEditMode(true)}
-            onDelete={remove.handle}
-            isPendingDelete={remove.isPending}
+            onDelete={remove}
+            isPendingDelete={isPendingRemove}
           />
         )}
       </div>

--- a/src/features/comment/hooks/useCommentMutation.ts
+++ b/src/features/comment/hooks/useCommentMutation.ts
@@ -1,73 +1,74 @@
 import { useTransition } from "react";
-import { toast } from "sonner";
 import {
   createRoadmapComment,
   deleteRoadmapComment,
   editRoadmapComment,
 } from "@/actions/comment";
+import { MutationOption } from "@/types";
 import { Comment, CommentForm } from "../type";
 
-type CommentMutationOptions = {
-  comment?: Comment;
-  create?: {
-    onSuccess?: () => void;
-  };
-  edit?: {
-    onSuccess?: () => void;
-  };
-  remove?: {
-    onSuccess?: () => void;
-  };
-};
+export const useCreateComment = (options?: MutationOption) => {
+  const [isPending, startTransition] = useTransition();
 
-export default function useCommentMutation(
-  options: CommentMutationOptions = {},
-) {
-  const [isPendingDelete, startTransitionDelete] = useTransition();
-
-  const create = async (data: CommentForm) => {
-    const response = await createRoadmapComment(data);
-
-    if (response.success) {
-      toast.success(response.message);
-      options.create?.onSuccess?.();
-    } else {
-      toast.error(response.message);
-    }
-  };
-
-  const edit = async (data: CommentForm) => {
-    const response = await editRoadmapComment(data);
-
-    if (response.success) {
-      toast.success(response.message);
-      options.edit?.onSuccess?.();
-    } else {
-      toast.error(response.message);
-    }
-  };
-
-  const remove = () => {
-    startTransitionDelete(async () => {
-      if (!options.comment) return;
-
-      const response = await deleteRoadmapComment(options.comment.id);
+  const mutate = async (data: CommentForm) => {
+    startTransition(async () => {
+      const response = await createRoadmapComment(data);
 
       if (response.success) {
-        toast.success(response.message);
-        options.remove?.onSuccess?.();
+        options?.onSuccess?.(response);
       } else {
-        toast.error(response.message);
+        options?.onError?.(response);
       }
     });
   };
 
   return {
-    create,
-    edit,
-    remove: {
-      handle: remove,
-      isPending: isPendingDelete,
-    },
+    isPending,
+    mutate,
   };
-}
+};
+
+export const useEditComment = (options?: MutationOption) => {
+  const [isPending, startTransition] = useTransition();
+
+  const mutate = async (data: CommentForm) => {
+    startTransition(async () => {
+      const response = await editRoadmapComment(data);
+
+      if (response.success) {
+        options?.onSuccess?.(response);
+      } else {
+        options?.onError?.(response);
+      }
+    });
+  };
+
+  return {
+    isPending,
+    mutate,
+  };
+};
+
+export const useDeleteComment = (
+  comment: Comment,
+  options?: MutationOption,
+) => {
+  const [isPending, startTransition] = useTransition();
+
+  const mutate = async () => {
+    startTransition(async () => {
+      const response = await deleteRoadmapComment(comment.id);
+
+      if (response.success) {
+        options?.onSuccess?.(response);
+      } else {
+        options?.onError?.(response);
+      }
+    });
+  };
+
+  return {
+    isPending,
+    mutate,
+  };
+};

--- a/src/features/comment/hooks/useCommentMutation.ts
+++ b/src/features/comment/hooks/useCommentMutation.ts
@@ -4,10 +4,12 @@ import {
   deleteRoadmapComment,
   editRoadmapComment,
 } from "@/actions/comment";
-import { MutationOption } from "@/types";
+import { MutationOption, MutationResult } from "@/types";
 import { Comment, CommentForm } from "../type";
 
-export const useCreateComment = (options?: MutationOption) => {
+export const useCreateComment = (
+  options?: MutationOption,
+): MutationResult<void, CommentForm> => {
   const [isPending, startTransition] = useTransition();
 
   const mutate = async (data: CommentForm) => {
@@ -28,7 +30,9 @@ export const useCreateComment = (options?: MutationOption) => {
   };
 };
 
-export const useEditComment = (options?: MutationOption) => {
+export const useEditComment = (
+  options?: MutationOption,
+): MutationResult<void, CommentForm> => {
   const [isPending, startTransition] = useTransition();
 
   const mutate = async (data: CommentForm) => {
@@ -52,7 +56,7 @@ export const useEditComment = (options?: MutationOption) => {
 export const useDeleteComment = (
   comment: Comment,
   options?: MutationOption,
-) => {
+): MutationResult => {
   const [isPending, startTransition] = useTransition();
 
   const mutate = async () => {

--- a/src/features/roadmap/components/RoadmapActions.tsx
+++ b/src/features/roadmap/components/RoadmapActions.tsx
@@ -72,13 +72,13 @@ export default function RoadmapActions({ roadmap }: RoadmapActionsProps) {
   return (
     <div className="flex items-center gap-[1px]">
       <RoadmapLikeButton
-        likeCount={likeState.likeCount}
-        isLiked={likeState.isLiked}
+        likeCount={likeState?.likeCount || 0}
+        isLiked={likeState?.isLiked || false}
         onToggleLike={handleLike}
         isPending={isLikePending}
       />
       <RoadmapBookmarkButton
-        isBookmarked={bookmarkState}
+        isBookmarked={bookmarkState || false}
         onToggleBookmark={handleBookmark}
         isPending={isBookmarkPending}
       />

--- a/src/features/roadmap/components/RoadmapActions.tsx
+++ b/src/features/roadmap/components/RoadmapActions.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { authClient } from "@/lib/auth-client";
-import useRoadmapMutation from "../hooks/useRoadmapMutation";
+import {
+  useBookmarkRoadmap,
+  useDeleteRoadmap,
+  useLikeRoadmap,
+} from "../hooks/useRoadmapMutation";
 import { useShareRoadmap } from "../hooks/useShareRoadmap";
 import { Roadmap } from "../type";
 import { RoadmapDeleteButton } from "./RoadmapDeleteButton";
@@ -21,27 +26,43 @@ export default function RoadmapActions({ roadmap }: RoadmapActionsProps) {
   const router = useRouter();
 
   const { handleKakaoShareClick, handleCopyUrlClick } = useShareRoadmap();
-  const { like, bookmark, remove } = useRoadmapMutation({
+
+  const {
+    mutate: like,
+    state: likeState,
+    isPending: isLikePending,
+  } = useLikeRoadmap(roadmap);
+
+  const {
+    mutate: bookmark,
+    state: bookmarkState,
+    isPending: isBookmarkPending,
+  } = useBookmarkRoadmap(roadmap);
+
+  const { mutate: remove, isPending: isRemovePending } = useDeleteRoadmap(
     roadmap,
-    remove: {
+    {
       onSuccess: () => {
         router.replace("/");
       },
+      onError: (error) => {
+        toast.error(error.message);
+      },
     },
-  });
+  );
 
   return (
     <div className="flex items-center gap-[1px]">
       <RoadmapLikeButton
-        likeCount={like.state.likeCount}
-        isLiked={like.state.isLiked}
-        onToggleLike={like.handle}
-        isPending={like.isPending}
+        likeCount={likeState.likeCount}
+        isLiked={likeState.isLiked}
+        onToggleLike={like}
+        isPending={isLikePending}
       />
       <RoadmapBookmarkButton
-        isBookmarked={bookmark.state}
-        onToggleBookmark={bookmark.handle}
-        isPending={bookmark.isPending}
+        isBookmarked={bookmarkState}
+        onToggleBookmark={bookmark}
+        isPending={isBookmarkPending}
       />
       <RoadmapShareButton
         onKakaoShareClick={handleKakaoShareClick}
@@ -50,10 +71,7 @@ export default function RoadmapActions({ roadmap }: RoadmapActionsProps) {
       {isAuthor && (
         <>
           <RoadmapEditButton href={`/roadmap/edit/${roadmap.externalId}`} />
-          <RoadmapDeleteButton
-            onDelete={remove.handle}
-            isPending={remove.isPending}
-          />
+          <RoadmapDeleteButton onDelete={remove} isPending={isRemovePending} />
         </>
       )}
     </div>

--- a/src/features/roadmap/components/RoadmapActions.tsx
+++ b/src/features/roadmap/components/RoadmapActions.tsx
@@ -51,17 +51,35 @@ export default function RoadmapActions({ roadmap }: RoadmapActionsProps) {
     },
   );
 
+  const handleLike = () => {
+    if (!session) {
+      toast.error("로그인이 필요합니다.");
+      return;
+    }
+
+    return like();
+  };
+
+  const handleBookmark = () => {
+    if (!session) {
+      toast.error("로그인이 필요합니다.");
+      return;
+    }
+
+    return bookmark();
+  };
+
   return (
     <div className="flex items-center gap-[1px]">
       <RoadmapLikeButton
         likeCount={likeState.likeCount}
         isLiked={likeState.isLiked}
-        onToggleLike={like}
+        onToggleLike={handleLike}
         isPending={isLikePending}
       />
       <RoadmapBookmarkButton
         isBookmarked={bookmarkState}
-        onToggleBookmark={bookmark}
+        onToggleBookmark={handleBookmark}
         isPending={isBookmarkPending}
       />
       <RoadmapShareButton

--- a/src/features/roadmap/components/RoadmapForm.tsx
+++ b/src/features/roadmap/components/RoadmapForm.tsx
@@ -4,6 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { useRouter } from "next/navigation";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
   Form,
@@ -29,7 +30,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { FILE_LIMIT_SIZE, ROADMAP_THEMES } from "@/constants";
 import useConfirmNavigation from "@/hooks/useConfirmNavigation";
 import { authClient } from "@/lib/auth-client";
-import useRoadmapMutation from "../hooks/useRoadmapMutation";
+import { useCreateRoadmap, useEditRoadmap } from "../hooks/useRoadmapMutation";
 import {
   Roadmap,
   RoadmapCategory,
@@ -107,16 +108,27 @@ export default function RoadmapForm({
       categories.find((item) => item.id === formData.categoryId) || null,
   });
 
-  const { create, edit } = useRoadmapMutation({
-    create: {
-      onSuccess: (externalId) => {
-        router.replace(`/roadmap/${externalId}`);
-      },
+  const { mutate: create } = useCreateRoadmap({
+    onSuccess: (result) => {
+      toast.success(result.message);
+      if (result.payload?.externalId) {
+        router.replace(`/roadmap/${result.payload.externalId}`);
+      }
     },
-    edit: {
-      onSuccess: (externalId) => {
-        router.replace(`/roadmap/${externalId}`);
-      },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+  });
+
+  const { mutate: edit } = useEditRoadmap({
+    onSuccess: (result) => {
+      toast.success(result.message);
+      if (result.payload?.externalId) {
+        router.replace(`/roadmap/${result.payload.externalId}`);
+      }
+    },
+    onError: (error) => {
+      toast.error(error.message);
     },
   });
 

--- a/src/features/roadmap/hooks/useRoadmapMutation.ts
+++ b/src/features/roadmap/hooks/useRoadmapMutation.ts
@@ -11,33 +11,110 @@ import {
 } from "@/actions/roadmap";
 import { authClient } from "@/lib/auth-client";
 import { uploadImageByClient } from "@/lib/r2-client";
+import { MutationOption } from "@/types";
 import { Roadmap, RoadmapForm, RoadmapFormWithUploadedUrl } from "../type";
 
-type RoadmapMutationOptions = {
-  roadmap?: Roadmap;
-  create?: {
-    onSuccess?: (externalId?: string) => void;
+export const useCreateRoadmap = (
+  options?: MutationOption<{ externalId?: string }>,
+) => {
+  const [isPending, startTransition] = useTransition();
+
+  const mutate = async (data: RoadmapForm) => {
+    startTransition(async () => {
+      if (data.thumbnail instanceof File) {
+        try {
+          const uploadResponse = await uploadImageByClient(data.thumbnail);
+          data.thumbnail = uploadResponse;
+        } catch (error) {
+          toast.error(
+            `${error instanceof Error ? error.message : "이미지 업로드 실패"}`,
+          );
+          return;
+        }
+      }
+
+      const response = await createRoadmap(data as RoadmapFormWithUploadedUrl);
+
+      if (response.success) {
+        options?.onSuccess?.(response);
+      } else {
+        options?.onError?.(response);
+      }
+    });
   };
-  edit?: {
-    onSuccess?: (externalId?: string) => void;
-  };
-  remove?: {
-    onSuccess?: () => void;
+
+  return {
+    isPending,
+    mutate,
   };
 };
 
-export default function useRoadmapMutation(
-  options: RoadmapMutationOptions = {},
-) {
+export const useEditRoadmap = (
+  options?: MutationOption<{ externalId?: string }>,
+) => {
+  const [isPending, startTransition] = useTransition();
+
+  const mutate = async (data: RoadmapForm) => {
+    startTransition(async () => {
+      if (data.thumbnail instanceof File) {
+        try {
+          const uploadResponse = await uploadImageByClient(data.thumbnail);
+          data.thumbnail = uploadResponse;
+        } catch (error) {
+          toast.error(
+            `${error instanceof Error ? error.message : "이미지 업로드 실패"}`,
+          );
+          return;
+        }
+      }
+
+      const response = await editRoadmap(data as RoadmapFormWithUploadedUrl);
+
+      if (response.success) {
+        options?.onSuccess?.(response);
+      } else {
+        options?.onError?.(response);
+      }
+    });
+  };
+
+  return {
+    isPending,
+    mutate,
+  };
+};
+
+export const useDeleteRoadmap = (
+  roadmap: Roadmap,
+  options?: MutationOption,
+) => {
+  const [isPending, startTransition] = useTransition();
+
+  const mutate = async () => {
+    startTransition(async () => {
+      const response = await deleteRoadmap(roadmap.id);
+
+      if (response.success) {
+        options?.onSuccess?.(response);
+      } else {
+        options?.onError?.(response);
+      }
+    });
+  };
+
+  return {
+    isPending,
+    mutate,
+  };
+};
+
+export const useLikeRoadmap = (roadmap: Roadmap, options?: MutationOption) => {
   const { data: session } = authClient.useSession();
-
-  const [isPendingDelete, startTransitionDelete] = useTransition();
-
-  const [isPendingLike, startTransitionLike] = useTransition();
-  const [likeState, setLikeState] = useOptimistic(
+  const [isPending, startTransition] = useTransition();
+  const [state, setState] = useOptimistic(
     {
-      isLiked: options.roadmap?.isLiked || false,
-      likeCount: options.roadmap?.likeCount || 0,
+      isLiked: roadmap?.isLiked || false,
+      likeCount: roadmap?.likeCount || 0,
     },
     (prev, newState: boolean) => {
       return {
@@ -47,141 +124,77 @@ export default function useRoadmapMutation(
     },
   );
 
-  const [isPendingBookmark, startTransitionBookmark] = useTransition();
-  const [bookmarkState, setBookmarkState] = useOptimistic(
-    options.roadmap?.isBookmarked || false,
-    (prev, newState: boolean) => newState,
-  );
-
-  const create = async (data: RoadmapForm) => {
-    if (data.thumbnail instanceof File) {
-      try {
-        const uploadResponse = await uploadImageByClient(data.thumbnail);
-        data.thumbnail = uploadResponse;
-      } catch (error) {
-        toast.error(
-          `${error instanceof Error ? error.message : "이미지 업로드 실패"}`,
-        );
-        return;
-      }
-    }
-
-    const response = await createRoadmap(data as RoadmapFormWithUploadedUrl);
-
-    if (response.success) {
-      toast.success(response.message);
-      options.create?.onSuccess?.(response.payload?.externalId);
-    } else {
-      toast.error(response.message);
-    }
-  };
-
-  const edit = async (data: RoadmapForm) => {
-    if (data.thumbnail instanceof File) {
-      try {
-        const uploadResponse = await uploadImageByClient(data.thumbnail);
-        data.thumbnail = uploadResponse;
-      } catch (error) {
-        toast.error(
-          `${error instanceof Error ? error.message : "이미지 업로드 실패"}`,
-        );
-        return;
-      }
-    }
-
-    const response = await editRoadmap(data as RoadmapFormWithUploadedUrl);
-
-    if (response.success) {
-      toast.success(response.message);
-      options.edit?.onSuccess?.(response.payload?.externalId);
-    } else {
-      toast.error(response.message);
-    }
-  };
-
-  const remove = () => {
-    startTransitionDelete(async () => {
-      if (!options.roadmap) return;
-
-      const response = await deleteRoadmap(options.roadmap.id);
-
-      if (response.success) {
-        toast.success(response.message);
-        options.remove?.onSuccess?.();
-      } else {
-        toast.error(response.message);
-      }
-    });
-  };
-
-  const handleToggleLike = async () => {
+  const mutate = async () => {
     if (!session) {
-      toast.error("로그인 후 이용해주세요.");
-      return;
+      return {
+        success: false,
+        message: "로그인 후 이용해주세요.",
+      };
     }
 
-    startTransitionLike(async () => {
-      if (!options.roadmap) return;
+    startTransition(async () => {
+      if (!roadmap) return;
 
-      const nextLike = !likeState.isLiked;
-      setLikeState(nextLike);
+      const nextLike = !state.isLiked;
+      setState(nextLike);
 
       const response = nextLike
-        ? await likeRoadmap(options?.roadmap.id, options?.roadmap.externalId)
-        : await unlikeRoadmap(options?.roadmap.id, options?.roadmap.externalId);
+        ? await likeRoadmap(roadmap.id, roadmap.externalId)
+        : await unlikeRoadmap(roadmap.id, roadmap.externalId);
 
       if (!response.success) {
-        setLikeState(!nextLike);
-        toast.error(response.message);
-      }
-    });
-  };
-
-  const handleToggleBookmark = async () => {
-    if (!session) {
-      toast.error("로그인 후 이용해주세요.");
-      return;
-    }
-
-    startTransitionBookmark(async () => {
-      if (!options.roadmap) return;
-
-      const nextBookmark = !bookmarkState;
-      setBookmarkState(nextBookmark);
-
-      const response = nextBookmark
-        ? await bookmarkRoadmap(
-            options?.roadmap.id,
-            options?.roadmap.externalId,
-          )
-        : await unbookmarkRoadmap(
-            options?.roadmap.id,
-            options?.roadmap.externalId,
-          );
-
-      if (!response.success) {
-        setBookmarkState(!nextBookmark);
-        toast.error(response.message);
+        setState(!nextLike);
+        options?.onError?.(response);
       }
     });
   };
 
   return {
-    create,
-    edit,
-    remove: {
-      handle: remove,
-      isPending: isPendingDelete,
-    },
-    like: {
-      handle: handleToggleLike,
-      isPending: isPendingLike,
-      state: likeState,
-    },
-    bookmark: {
-      handle: handleToggleBookmark,
-      isPending: isPendingBookmark,
-      state: bookmarkState,
-    },
+    isPending,
+    mutate,
+    state,
   };
-}
+};
+
+export const useBookmarkRoadmap = (
+  roadmap: Roadmap,
+  options?: MutationOption,
+) => {
+  const { data: session } = authClient.useSession();
+  const [isPending, startTransition] = useTransition();
+  const [state, setState] = useOptimistic(
+    roadmap?.isBookmarked || false,
+    (prev, newState: boolean) => newState,
+  );
+
+  const mutate = async () => {
+    if (!session) {
+      return {
+        success: false,
+        message: "로그인 후 이용해주세요.",
+      };
+    }
+
+    startTransition(async () => {
+      if (!roadmap) return;
+
+      const nextBookmark = !state;
+      setState(nextBookmark);
+
+      const response = nextBookmark
+        ? await bookmarkRoadmap(roadmap.id, roadmap.externalId)
+        : await unbookmarkRoadmap(roadmap.id, roadmap.externalId);
+
+      if (!response.success) {
+        setState(!nextBookmark);
+        options?.onError?.(response);
+      }
+    });
+  };
+
+  return {
+    isPending,
+    mutate,
+    state,
+  };
+};

--- a/src/features/roadmap/hooks/useRoadmapMutation.ts
+++ b/src/features/roadmap/hooks/useRoadmapMutation.ts
@@ -10,12 +10,14 @@ import {
   unlikeRoadmap,
 } from "@/actions/roadmap";
 import { uploadImageByClient } from "@/lib/r2-client";
-import { MutationOption } from "@/types";
+import { MutationOption, MutationResult } from "@/types";
 import { Roadmap, RoadmapForm, RoadmapFormWithUploadedUrl } from "../type";
 
+type CreateRoadmapPayload = { externalId?: string };
+
 export const useCreateRoadmap = (
-  options?: MutationOption<{ externalId?: string }>,
-) => {
+  options?: MutationOption<CreateRoadmapPayload>,
+): MutationResult<CreateRoadmapPayload, RoadmapForm> => {
   const [isPending, startTransition] = useTransition();
 
   const mutate = async (data: RoadmapForm) => {
@@ -48,9 +50,11 @@ export const useCreateRoadmap = (
   };
 };
 
+type EditRoadmapPayload = { externalId?: string };
+
 export const useEditRoadmap = (
-  options?: MutationOption<{ externalId?: string }>,
-) => {
+  options?: MutationOption<EditRoadmapPayload>,
+): MutationResult<EditRoadmapPayload, RoadmapForm> => {
   const [isPending, startTransition] = useTransition();
 
   const mutate = async (data: RoadmapForm) => {
@@ -86,7 +90,7 @@ export const useEditRoadmap = (
 export const useDeleteRoadmap = (
   roadmap: Roadmap,
   options?: MutationOption,
-) => {
+): MutationResult => {
   const [isPending, startTransition] = useTransition();
 
   const mutate = async () => {
@@ -107,7 +111,12 @@ export const useDeleteRoadmap = (
   };
 };
 
-export const useLikeRoadmap = (roadmap: Roadmap, options?: MutationOption) => {
+type LikeRoadmapPayload = { isLiked: boolean; likeCount: number };
+
+export const useLikeRoadmap = (
+  roadmap: Roadmap,
+  options?: MutationOption,
+): MutationResult<LikeRoadmapPayload> => {
   const [isPending, startTransition] = useTransition();
   const [state, setState] = useOptimistic(
     {
@@ -147,10 +156,12 @@ export const useLikeRoadmap = (roadmap: Roadmap, options?: MutationOption) => {
   };
 };
 
+type BookmarkRoadmapPayload = boolean;
+
 export const useBookmarkRoadmap = (
   roadmap: Roadmap,
   options?: MutationOption,
-) => {
+): MutationResult<BookmarkRoadmapPayload> => {
   const [isPending, startTransition] = useTransition();
   const [state, setState] = useOptimistic(
     roadmap?.isBookmarked || false,

--- a/src/features/roadmap/hooks/useRoadmapMutation.ts
+++ b/src/features/roadmap/hooks/useRoadmapMutation.ts
@@ -9,7 +9,6 @@ import {
   unbookmarkRoadmap,
   unlikeRoadmap,
 } from "@/actions/roadmap";
-import { authClient } from "@/lib/auth-client";
 import { uploadImageByClient } from "@/lib/r2-client";
 import { MutationOption } from "@/types";
 import { Roadmap, RoadmapForm, RoadmapFormWithUploadedUrl } from "../type";
@@ -109,7 +108,6 @@ export const useDeleteRoadmap = (
 };
 
 export const useLikeRoadmap = (roadmap: Roadmap, options?: MutationOption) => {
-  const { data: session } = authClient.useSession();
   const [isPending, startTransition] = useTransition();
   const [state, setState] = useOptimistic(
     {
@@ -125,13 +123,6 @@ export const useLikeRoadmap = (roadmap: Roadmap, options?: MutationOption) => {
   );
 
   const mutate = async () => {
-    if (!session) {
-      return {
-        success: false,
-        message: "로그인 후 이용해주세요.",
-      };
-    }
-
     startTransition(async () => {
       if (!roadmap) return;
 
@@ -160,7 +151,6 @@ export const useBookmarkRoadmap = (
   roadmap: Roadmap,
   options?: MutationOption,
 ) => {
-  const { data: session } = authClient.useSession();
   const [isPending, startTransition] = useTransition();
   const [state, setState] = useOptimistic(
     roadmap?.isBookmarked || false,
@@ -168,13 +158,6 @@ export const useBookmarkRoadmap = (
   );
 
   const mutate = async () => {
-    if (!session) {
-      return {
-        success: false,
-        message: "로그인 후 이용해주세요.",
-      };
-    }
-
     startTransition(async () => {
       if (!roadmap) return;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,24 @@
 import { z } from "zod";
 
-export type ServerActionResult<T = undefined> =
-  | { success: true; message: string; payload?: T }
-  | { success: false; message: string };
+export type ServerActionResult<T = unknown> =
+  | ServerActionSuccess<T>
+  | ServerActionFailure;
+
+export type ServerActionSuccess<T> = {
+  success: true;
+  message: string;
+  payload?: T;
+};
+
+export type ServerActionFailure = {
+  success: false;
+  message: string;
+};
+
+export type MutationOption<T = unknown> = {
+  onSuccess?: (response: ServerActionSuccess<T>) => void;
+  onError?: (response: ServerActionFailure) => void;
+};
 
 export type TargetType = "roadmap" | "comment";
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,12 @@ export type ServerActionFailure = {
   message: string;
 };
 
+export type MutationResult<TPayload = unknown, TInput = void> = {
+  isPending: boolean;
+  mutate: (input: TInput) => void | Promise<void>;
+  state?: TPayload;
+};
+
 export type MutationOption<T = unknown> = {
   onSuccess?: (response: ServerActionSuccess<T>) => void;
   onError?: (response: ServerActionFailure) => void;


### PR DESCRIPTION


## :memo: Description
### 작업개요
#### Refactor: mutation 훅의 UI 및 클라이언트 로직 분리, 구조 통일
이번 리팩토링의 목적은 mutation 훅 내부에 혼재돼 있던 UI 로직과 클라이언트 세션 로직을 제거하고,
비즈니스 로직만 담당하는 순수한 훅으로 정리하는 목적입니다.

#### 기존 문제점
mutation 훅 내부에서 toast로 알림을 띄우는 등 UI 관련 로직이 섞여 있었고, authClient.useSession()을 호출하여 클라이언트 세션 상태를 직접 확인하는 책임까지 포함되어 있었습니다.

#### 개선 내용
- 모든 mutation 훅은 다음 세 가지 항목만 반환하도록 통일했습니다
  - isPending: 요청 진행 여부
  - mutate: 서버 액션 실행 및 콜백 트리거
  - state (optional): 낙관적 UI 처리를 위한 상태 (필요한 경우에만)

- 클라이언트 세션 확인은 UI 컴포넌트에서 직접 처리하도록 책임을 분리하였고,
- 성공/실패에 따른 UI 피드백(toast)도 onSuccess, onError 옵션을 통해 사용하는 쪽(UI 컴포넌트)에서 전달하도록 구조를 변경했습니다. 훅 내부는 해당 옵션의 존재 여부만 알고 실행하며, UI의 존재를 알지 못합니다.

### 참고한점
처음에는 React 19의 useActionState를 활용해 리팩토링을 시도했습니다. 폼을 사용하지 않는 일반 액션에도 useActionState를 적용할 수는 있었지만, 사용자 피드백(예: toast) 처리를 선언적으로 구성하기 어려웠고,결과에 따른 분기 로직을 명확히 나누기에도 한계가 있었습니다.
(useActionState는 결과값을 기반으로 상태를 구성할 수는 있지만, UI 피드백을 선언적으로 다루기엔 제약이 있었습니다.)

결국 이번 구조는 useActionState의 패턴에서 영감을 받되, 직접 상태 관리(isPending, state)와 콜백(onSuccess, onError) 체계를 정의해
훅 내부는 비즈니스 로직에만 집중하고, 사용자 피드백은 UI 컴포넌트에서 선언적으로 처리할 수 있도록 설계했습니다. (사용자 피드백 콜백(onSuccess, onError)만 고려하지 않아도 된다면, useActionState를 그대로 써도 큰 문제는 없었을 것 같습니다.)

<!-- 어떤 내용의 PR인지 작성해 주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

## :cyclone: PR Type

어떤 변경 사항이 있나요?

<!-- 해당 사항에 체크해 주세요. -->

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### PR

<!-- 작성중인 PR인 경우, Draft 모드로 생성해주세요. -->

- [x] Branch Convention 확인
  > `feat/*` 기능 구현, `fix/*` 버그 수정, `refactor/*` 개선
- [x] Base Branch 확인
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정
